### PR TITLE
Fix bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "bower_components",
     "test",
     "tests",
-    "sandbox",
+    "sandbox"
   ]
 }


### PR DESCRIPTION
The extra `,` causes referencing the library via bower to fail.